### PR TITLE
fix(js): Bind exchange to source

### DIFF
--- a/trimsock.js/package.json
+++ b/trimsock.js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trimsock",
   "private": true,
-  "version": "0.13.0",
+  "version": "0.13.1",
   "type": "module",
   "workspaces": [
     "packages/*",

--- a/trimsock.js/packages/trimsock-bun/package.json
+++ b/trimsock.js/packages/trimsock-bun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxssake/trimsock-bun",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "module": "lib/trimsock.ts",
   "type": "module",
   "author": "Tamás Gálffy",

--- a/trimsock.js/packages/trimsock-js/lib/reactor.ts
+++ b/trimsock.js/packages/trimsock-js/lib/reactor.ts
@@ -72,7 +72,7 @@ export class ReactorExchange<T> implements Exchange<T> {
       source: T,
     ) => ThisType<ReactorExchange<T>>,
     private free: () => void,
-    private generateExchangeId: ExchangeIdGenerator = makeDefaultIdGenerator(),
+    private generateExchangeId: ExchangeIdGenerator = makeDefaultIdGenerator(4),
     private command?: Command,
   ) {
     // Process originating command
@@ -283,16 +283,52 @@ export class ReactorExchange<T> implements Exchange<T> {
   }
 }
 
+export class ExchangeMap<T, E extends Exchange<T> = Exchange<T>> {
+  private data: Map<string, Set<E>> = new Map();
+
+  has(exchangeId: string, source: T): boolean {
+    return this.get(exchangeId, source) !== undefined;
+  }
+
+  get(exchangeId: string, source: T): E | undefined {
+    return this.data
+      .get(exchangeId)
+      ?.values()
+      ?.find((it) => it.source === source);
+  }
+
+  set(exchangeId: string, exchange: E): void {
+    const source = exchange.source;
+
+    this.delete(exchangeId, source);
+
+    const exchanges = this.data.get(exchangeId) ?? new Set();
+    exchanges.add(exchange);
+    this.data.set(exchangeId, exchanges);
+  }
+
+  delete(exchangeId: string, source: T): void {
+    const exchanges = this.data.get(exchangeId);
+    if (!exchanges) return;
+
+    const item = exchanges.values().find((it) => it.source === source);
+    if (item === undefined) return;
+
+    exchanges.delete(item);
+    if (exchanges.size === 0) this.data.delete(exchangeId);
+  }
+}
+
 export abstract class Reactor<T> {
   private handlers: Map<string, CommandHandler<T>> = new Map();
   private defaultHandler: CommandHandler<T> = () => {};
   private errorHandler: CommandErrorHandler<T> = () => {};
 
-  private exchanges: Map<string, ReactorExchange<T>> = new Map();
+  private exchanges = new ExchangeMap<T, ReactorExchange<T>>();
 
   constructor(
     private trimsock: Trimsock = new Trimsock().withConventions(),
-    private generateExchangeId: ExchangeIdGenerator = makeDefaultIdGenerator(),
+    private generateExchangeId: ExchangeIdGenerator = makeDefaultIdGenerator(4),
   ) {}
 
   public on(commandName: string, handler: CommandHandler<T>): this {
@@ -338,7 +374,7 @@ export abstract class Reactor<T> {
   private handle(command: Command, source: T) {
     const exchangeId = command.id;
 
-    if (this.isNewExchange(command)) {
+    if (this.isNewExchange(command, source)) {
       const handler = this.handlers.get(command.name);
       const exchange = this.ensureExchange(command, source);
 
@@ -349,17 +385,22 @@ export abstract class Reactor<T> {
         this.errorHandler(command, exchange, error);
       }
     } else {
+      console.log("Looking for exchange", {
+        exchangeId,
+        source: (source as any).data.sessionId,
+      });
       const exchange =
-        exchangeId !== undefined && this.exchanges.get(exchangeId);
+        exchangeId !== undefined && this.exchanges.get(exchangeId, source);
       assert(exchange, `Unknown exchange id: ${exchangeId}!`);
       exchange.push(command);
     }
   }
 
-  private isNewExchange(command: Command): boolean {
+  private isNewExchange(command: Command, source: T): boolean {
     const exchangeId = command.id;
     const hasExchangeId = exchangeId !== undefined;
-    const knownExchange = hasExchangeId && this.exchanges.get(exchangeId);
+    const knownExchange =
+      hasExchangeId && this.exchanges.get(exchangeId, source);
 
     // Request-response
     if (command.isRequest) {
@@ -385,9 +426,12 @@ export abstract class Reactor<T> {
     return true;
   }
 
-  private findExchange(command: Command): ReactorExchange<T> | undefined {
+  private findExchange(
+    command: Command,
+    source: T,
+  ): ReactorExchange<T> | undefined {
     const id = command.requestId ?? command.streamId;
-    return id !== undefined ? this.exchanges.get(id) : undefined;
+    return id !== undefined ? this.exchanges.get(id, source) : undefined;
   }
 
   private ensureExchange(command: Command, source: T): ReactorExchange<T> {
@@ -396,7 +440,7 @@ export abstract class Reactor<T> {
     if (id === undefined) return this.makeExchange(command, source);
 
     const exchange =
-      this.findExchange(command) ?? this.makeExchange(command, source);
+      this.findExchange(command, source) ?? this.makeExchange(command, source);
     this.exchanges.set(id, exchange);
     return exchange;
   }
@@ -411,7 +455,7 @@ export abstract class Reactor<T> {
       (cmd, to) => this.ensureExchange(new Command(cmd), to),
       () => {
         const exchangeId = command?.requestId ?? command?.streamId;
-        if (exchangeId !== undefined) this.exchanges.delete(exchangeId);
+        if (exchangeId !== undefined) this.exchanges.delete(exchangeId, source);
       },
       this.generateExchangeId,
       command,

--- a/trimsock.js/packages/trimsock-js/package.json
+++ b/trimsock.js/packages/trimsock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxssake/trimsock-js",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "module": "dist/index.js",
   "type": "module",
   "author": "Tamás Gálffy",

--- a/trimsock.js/packages/trimsock-js/spec/reactor/exchange.map.spec.ts
+++ b/trimsock.js/packages/trimsock-js/spec/reactor/exchange.map.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { Command } from "@lib/command.js";
+import { type Exchange, ExchangeMap } from "@lib/reactor.js";
+import { TestingExchange } from "./testing.exchange.js";
+
+describe("ExchangeMap", () => {
+  test("should store exchange", () => {
+    const map = new ExchangeMap<string, TestingExchange>();
+    const exchange = new TestingExchange("1", new Command({ name: "foo" }));
+
+    map.set("a", exchange);
+
+    expect(map.has("a", "1")).toBeTrue();
+    expect(map.get("a", "1")).toBe(exchange);
+  });
+
+  test("should delete exchange", () => {
+    const map = new ExchangeMap<string, TestingExchange>();
+
+    map.set("a", new TestingExchange("1", new Command({ name: "foo" })));
+    map.set("b", new TestingExchange("1", new Command({ name: "bar" })));
+    map.delete("a", "1");
+
+    expect(map.has("a", "1")).toBeFalse();
+    expect(map.get("a", "1")).toBeUndefined();
+  });
+
+  test("should bind same id to source", () => {
+    // Have two exchanges with the same ID, but from different sources
+    // The map should correctly return the exchange bound to the queried source
+    const map = new ExchangeMap<string, TestingExchange>();
+    const exchanges = [
+      new TestingExchange("1", new Command({ name: "foo" })),
+      new TestingExchange("1", new Command({ name: "bar" })),
+    ];
+
+    map.set("a", exchanges[0]);
+    map.set("b", exchanges[1]);
+
+    expect(map.has("a", "1")).toBeTrue();
+    expect(map.has("b", "1")).toBeTrue();
+
+    expect(map.get("a", "1")).toBe(exchanges[0]);
+    expect(map.get("b", "1")).toBe(exchanges[1]);
+  });
+});

--- a/trimsock.js/packages/trimsock-node/package.json
+++ b/trimsock.js/packages/trimsock-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxssake/trimsock-node",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "module": "./dist/index.js",
   "type": "module",
   "author": "Tamás Gálffy",


### PR DESCRIPTION
When two or more clients were connected to a single server, clients could steal eachother's exchange ID's and use them as their own, e.g.

```
S>A: answer?lP2f Give\sme\sa\snumber\splease
B>S: .lP2f 72
```
*( S: Server, A: client A, B: client B )

Even though the server requested data from client A, it accepted client B's answer without issue. This PR binds each exchange to the peer, so this kind of ID stealing can't happen.

Closes #11 