### PR TITLE
feat(js): Handle ingestion errors in Reactor

### DIFF
--- a/trimsock.js/package.json
+++ b/trimsock.js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trimsock",
   "private": true,
-  "version": "0.18.2",
+  "version": "0.18.3",
   "type": "module",
   "scripts": {
     "docs": "typedoc",

--- a/trimsock.js/package.json
+++ b/trimsock.js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trimsock",
   "private": true,
-  "version": "0.18.3",
+  "version": "0.19.0",
   "type": "module",
   "scripts": {
     "docs": "typedoc",

--- a/trimsock.js/packages/trimsock-bun/package.json
+++ b/trimsock.js/packages/trimsock-bun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxssake/trimsock-bun",
-  "version": "0.18.3",
+  "version": "0.19.0",
   "module": "dist/index.js",
   "type": "module",
   "author": "Tamás Gálffy",

--- a/trimsock.js/packages/trimsock-bun/package.json
+++ b/trimsock.js/packages/trimsock-bun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxssake/trimsock-bun",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "module": "dist/index.js",
   "type": "module",
   "author": "Tamás Gálffy",

--- a/trimsock.js/packages/trimsock-js/lib/reactor.ts
+++ b/trimsock.js/packages/trimsock-js/lib/reactor.ts
@@ -31,7 +31,10 @@ export type CommandErrorHandler<T> = (
   error: unknown,
 ) => void;
 
-export type IngestErrorHandler = (error: unknown, input: Buffer) => void;
+export type IngestErrorHandler = (
+  error: unknown,
+  input: string | Buffer,
+) => void;
 
 /**
  * Callback type for generating exchange ID's

--- a/trimsock.js/packages/trimsock-js/lib/reactor.ts
+++ b/trimsock.js/packages/trimsock-js/lib/reactor.ts
@@ -566,8 +566,8 @@ export abstract class Reactor<T> {
   /**
    * Register a command handler
    *
-* Note that one command can only have one handler active at a time. Calling
-* this method will replace the currently active handler, if it exists.
+   * Note that one command can only have one handler active at a time. Calling
+   * this method will replace the currently active handler, if it exists.
    *
    * @param commandName command name
    * @param handler callback function
@@ -582,9 +582,9 @@ export abstract class Reactor<T> {
    *
    * Whenever a command is received that has no associated handler, the unknown
    * command handler is called.
-  *
-  * Note that there's only one handler at any time, calling this method will
-  * replace the currently active handler.
+   *
+   * Note that there's only one handler at any time, calling this method will
+   * replace the currently active handler.
    *
    * @param handler callback function
    */
@@ -598,9 +598,9 @@ export abstract class Reactor<T> {
    *
    * Whenever an error occurs during command processing ( e.g. in one of the
    * registered handlers ), the error handler is called.
-  *
-  * Note that there's only one handler at any time, calling this method will
-  * replace the currently active handler.
+   *
+   * Note that there's only one handler at any time, calling this method will
+   * replace the currently active handler.
    *
    * @param handler callback function
    */
@@ -610,17 +610,17 @@ export abstract class Reactor<T> {
   }
 
   /**
-  * Register an ingest error handler
-  *
-  * If the reactor receives input that it can't manage ( e.g. it's malformed or
-  * the command is too long ), it rejects the command and calls the ingest error
-  * handler.
-  *
-  * Note that there's only one handler at any time, calling this method will
-  * replace the currently active handler.
-  *
-  * @param handler callback function
-*/
+   * Register an ingest error handler
+   *
+   * If the reactor receives input that it can't manage ( e.g. it's malformed or
+   * the command is too long ), it rejects the command and calls the ingest error
+   * handler.
+   *
+   * Note that there's only one handler at any time, calling this method will
+   * replace the currently active handler.
+   *
+   * @param handler callback function
+   */
   public onIngestError(handler: IngestErrorHandler): this {
     this.ingestErrorHandler = handler;
     return this;
@@ -718,11 +718,11 @@ export abstract class Reactor<T> {
       if (typeof data === "string") reader.ingest(Buffer.from(data, "utf8"));
       else reader.ingest(data);
 
-      await Promise.all(reader.commands()
-        .map(it => this.handle(new Command(it), source))
+      await Promise.all(
+        reader.commands().map((it) => this.handle(new Command(it), source)),
       );
     } catch (e) {
-      this.ingestErrorHandler(e, data)
+      this.ingestErrorHandler(e, data);
     }
   }
 
@@ -758,8 +758,7 @@ export abstract class Reactor<T> {
 
       let filterIdx = 0;
       const next = async () => {
-        if (filterIdx >= this.filters.length)
-          await handler(command, exchange);
+        if (filterIdx >= this.filters.length) await handler(command, exchange);
         else {
           filterIdx += 1;
           await this.filters[filterIdx - 1](next, command, exchange);

--- a/trimsock.js/packages/trimsock-js/lib/reactor.ts
+++ b/trimsock.js/packages/trimsock-js/lib/reactor.ts
@@ -683,15 +683,19 @@ export abstract class Reactor<T> {
    * @param data incoming data
    * @param source source connection
    */
-  public ingest(data: Buffer | string, source: T): void {
-    // TODO: Invoke error handler when ingest fails?
-    const reader = this.ensureReaderFor(source);
+  public async ingest(data: Buffer | string, source: T): Promise<void> {
+    try {
+      const reader = this.ensureReaderFor(source);
 
-    if (typeof data === "string") reader.ingest(Buffer.from(data, "utf8"));
-    else reader.ingest(data);
+      if (typeof data === "string") reader.ingest(Buffer.from(data, "utf8"));
+      else reader.ingest(data);
 
-    for (const item of reader.commands()) {
-      this.handle(new Command(item), source);
+      await Promise.all(reader.commands()
+        .map(it => this.handle(new Command(it), source))
+      );
+    } catch (e) {
+      // TODO: Error handler
+      console.error("Ingest failed!", e)
     }
   }
 
@@ -727,7 +731,8 @@ export abstract class Reactor<T> {
 
       let filterIdx = 0;
       const next = async () => {
-        if (filterIdx >= this.filters.length) await handler(command, exchange);
+        if (filterIdx >= this.filters.length)
+          await handler(command, exchange);
         else {
           filterIdx += 1;
           await this.filters[filterIdx - 1](next, command, exchange);
@@ -740,13 +745,9 @@ export abstract class Reactor<T> {
         this.errorHandler(command, exchange, error);
       }
     } else {
-      const exchange = exchangeId !== undefined && this.exchanges.get(exchangeId, source);
-      if (!exchange) {
-        console.error(`Unknown exchange id: ${exchangeId}`); 
-        // note: temp swapped this to an error, will discuss with @elementbound how these errors should be processed
-        // this used to crash the program when bad data came over TCP, this means things like botnets would crash the application.
-        return;
-      }
+      const exchange =
+        exchangeId !== undefined && this.exchanges.get(exchangeId, source);
+      assert(exchange, `Unknown exchange id: ${exchangeId}!`);
       exchange.push(command);
     }
   }

--- a/trimsock.js/packages/trimsock-js/lib/reactor.ts
+++ b/trimsock.js/packages/trimsock-js/lib/reactor.ts
@@ -31,6 +31,8 @@ export type CommandErrorHandler<T> = (
   error: unknown,
 ) => void;
 
+export type IngestErrorHandler = (error: unknown, input: Buffer) => void;
+
 /**
  * Callback type for generating exchange ID's
  *
@@ -551,6 +553,7 @@ export abstract class Reactor<T> {
   private handlers: Map<string, CommandHandler<T>> = new Map();
   private defaultHandler: CommandHandler<T> = () => {};
   private errorHandler: CommandErrorHandler<T> = () => {};
+  private ingestErrorHandler: IngestErrorHandler = () => {};
   private filters: CommandFilter<T>[] = [];
 
   private exchanges = new ExchangeMap<T, ReactorExchange<T>>();
@@ -563,6 +566,8 @@ export abstract class Reactor<T> {
   /**
    * Register a command handler
    *
+* Note that one command can only have one handler active at a time. Calling
+* this method will replace the currently active handler, if it exists.
    *
    * @param commandName command name
    * @param handler callback function
@@ -577,6 +582,9 @@ export abstract class Reactor<T> {
    *
    * Whenever a command is received that has no associated handler, the unknown
    * command handler is called.
+  *
+  * Note that there's only one handler at any time, calling this method will
+  * replace the currently active handler.
    *
    * @param handler callback function
    */
@@ -590,11 +598,31 @@ export abstract class Reactor<T> {
    *
    * Whenever an error occurs during command processing ( e.g. in one of the
    * registered handlers ), the error handler is called.
+  *
+  * Note that there's only one handler at any time, calling this method will
+  * replace the currently active handler.
    *
    * @param handler callback function
    */
   public onError(handler: CommandErrorHandler<T>): this {
     this.errorHandler = handler;
+    return this;
+  }
+
+  /**
+  * Register an ingest error handler
+  *
+  * If the reactor receives input that it can't manage ( e.g. it's malformed or
+  * the command is too long ), it rejects the command and calls the ingest error
+  * handler.
+  *
+  * Note that there's only one handler at any time, calling this method will
+  * replace the currently active handler.
+  *
+  * @param handler callback function
+*/
+  public onIngestError(handler: IngestErrorHandler): this {
+    this.ingestErrorHandler = handler;
     return this;
   }
 
@@ -694,8 +722,7 @@ export abstract class Reactor<T> {
         .map(it => this.handle(new Command(it), source))
       );
     } catch (e) {
-      // TODO: Error handler
-      console.error("Ingest failed!", e)
+      this.ingestErrorHandler(e, data)
     }
   }
 

--- a/trimsock.js/packages/trimsock-js/lib/reactor.ts
+++ b/trimsock.js/packages/trimsock-js/lib/reactor.ts
@@ -740,9 +740,13 @@ export abstract class Reactor<T> {
         this.errorHandler(command, exchange, error);
       }
     } else {
-      const exchange =
-        exchangeId !== undefined && this.exchanges.get(exchangeId, source);
-      assert(exchange, `Unknown exchange id: ${exchangeId}!`);
+      const exchange = exchangeId !== undefined && this.exchanges.get(exchangeId, source);
+      if (!exchange) {
+        console.error(`Unknown exchange id: ${exchangeId}`); 
+        // note: temp swapped this to an error, will discuss with @elementbound how these errors should be processed
+        // this used to crash the program when bad data came over TCP, this means things like botnets would crash the application.
+        return;
+      }
       exchange.push(command);
     }
   }

--- a/trimsock.js/packages/trimsock-js/package.json
+++ b/trimsock.js/packages/trimsock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxssake/trimsock-js",
-  "version": "0.18.3",
+  "version": "0.19.0",
   "module": "dist/index.js",
   "type": "module",
   "author": "Tamás Gálffy",

--- a/trimsock.js/packages/trimsock-js/package.json
+++ b/trimsock.js/packages/trimsock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxssake/trimsock-js",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "module": "dist/index.js",
   "type": "module",
   "author": "Tamás Gálffy",

--- a/trimsock.js/packages/trimsock-js/spec/reactor/reactor.spec.ts
+++ b/trimsock.js/packages/trimsock-js/spec/reactor/reactor.spec.ts
@@ -26,29 +26,30 @@ describe("Reactor", () => {
 
     test("should not throw on unknown exchange", async () => {
       expect(
-        async () => 
-          await reactor.ingest(".1234 foo\n", "0")
-      ).not.toThrow()
-    })
+        async () => await reactor.ingest(".1234 foo\n", "0"),
+      ).not.toThrow();
+    });
 
     test("should never throw", async () => {
       // Throw random strings at the reactor and see if it fails
-      const count = 1024
-      const length = 32
-      const charset = "abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+-=,./<>?"
+      const count = 1024;
+      const length = 32;
+      const charset =
+        "abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+-=,./<>?";
 
-      const inputs = [...new Array(count)]
-        .map(() => [...new Array(length)]
-          .map(() => ~~(Math.random() * charset.length))
-          .map(idx => charset.charAt(idx))
-          .join("") + "\n"
-        )
+      const inputs = [...new Array(count)].map(
+        () =>
+          `${[...new Array(length)]
+            .map(() => ~~(Math.random() * charset.length))
+            .map((idx) => charset.charAt(idx))
+            .join("")}\n`,
+      );
 
-      const promise = Promise.all(inputs.map(it => reactor.ingest(it, "0")))
+      const promise = Promise.all(inputs.map((it) => reactor.ingest(it, "0")));
 
-      console.log("Randomized inputs: ", inputs)
-      expect(async () => await promise).not.toThrow()
-    })
+      console.log("Randomized inputs: ", inputs);
+      expect(async () => await promise).not.toThrow();
+    });
   });
 
   describe("knownCommands", () => {

--- a/trimsock.js/packages/trimsock-js/spec/reactor/reactor.spec.ts
+++ b/trimsock.js/packages/trimsock-js/spec/reactor/reactor.spec.ts
@@ -23,6 +23,32 @@ describe("Reactor", () => {
       // Outbox should be empty
       expect(reactor.outbox).toBeEmpty();
     });
+
+    test("should not throw on unknown exchange", async () => {
+      expect(
+        async () => 
+          await reactor.ingest(".1234 foo\n", "0")
+      ).not.toThrow()
+    })
+
+    test("should never throw", async () => {
+      // Throw random strings at the reactor and see if it fails
+      const count = 1024
+      const length = 32
+      const charset = "abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+-=,./<>?"
+
+      const inputs = [...new Array(count)]
+        .map(() => [...new Array(length)]
+          .map(() => ~~(Math.random() * charset.length))
+          .map(idx => charset.charAt(idx))
+          .join("") + "\n"
+        )
+
+      const promise = Promise.all(inputs.map(it => reactor.ingest(it, "0")))
+
+      console.log("Randomized inputs: ", inputs)
+      expect(async () => await promise).not.toThrow()
+    })
   });
 
   describe("knownCommands", () => {

--- a/trimsock.js/packages/trimsock-node/package.json
+++ b/trimsock.js/packages/trimsock-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxssake/trimsock-node",
-  "version": "0.18.3",
+  "version": "0.19.0",
   "module": "./dist/index.js",
   "type": "module",
   "author": "Tamás Gálffy",

--- a/trimsock.js/packages/trimsock-node/package.json
+++ b/trimsock.js/packages/trimsock-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxssake/trimsock-node",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "module": "./dist/index.js",
   "type": "module",
   "author": "Tamás Gálffy",


### PR DESCRIPTION
This is a fix for crashing when sending bad data over TCP.

Likely the proper fix is to swap to exceptions, and process them OR pass them to an error handler.

```bash
# 1 run netcat
nc localhost 9980
# 2 send bad data
/213/213.23.12/.3421
# 3 no crash with this fix, or crash without the fix
```